### PR TITLE
add php-curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 1. 将代码部署到 Web 服务器上。
 2. 配置服务器环境（Apache 或 Nginx），使 `/file/` 路径映射到 `proxy.php` 文件。
 3. 打开 `index.html` 文件即可使用。
+4. 依赖于 cURL 扩展支持，即 `php-curl`
 
 ### Apache 配置示例
 


### PR DESCRIPTION
修改readme，增加PHP cURL 扩展支持说明，原文档中未明确指出需安装，会导致`FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function`错误。